### PR TITLE
Fix c-two dependency version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,7 @@ requires-python = ">=3.12"
 dependencies = [
     "fastapi (>=0.115.12,<0.116.0)",
     "pyarrow (>=19.0.1,<20.0.0)",
-<<<<<<< HEAD
     "c-two (>=0.1.12,<0.2.0)",
-=======
-    "c-two (>=0.1.10,<0.2.0)",
->>>>>>> upstream/main
     "uvicorn (>=0.34.0,<0.35.0)",
     "pydantic-settings (>=2.8.1,<3.0.0)",
     "jinja2 (>=3.1.6,<4.0.0)",


### PR DESCRIPTION
Update the version constraint for the c-two dependency to ensure compatibility with other packages.