### PR TITLE
Refactor node editing logic to prevent duplicates

### DIFF
--- a/src/framework/src/components/resourceScene/scene.ts
+++ b/src/framework/src/components/resourceScene/scene.ts
@@ -224,14 +224,12 @@ export class SceneTree implements ISceneTree {
     // Node Editing //////////////////////////////////////////////////
 
     async startEditingNode(node: ISceneNode): Promise<void> {
-        // Do nothing if already editing
-        if (this.editingNodes.has(node)) {
-            return
+        // Add node to editing nodes if not already editing
+        if (!this.editingNodes.has(node)) {
+            this.editingNodes.add(node)
+            ;(node as SceneNode).pageContext = await SCENARIO_PAGE_CONTEXT_REGISTRY[node.scenarioNode.semanticPath].create(node)
         }
-
-        this.editingNodes.add(node)
-        ;(node as SceneNode).pageContext = await SCENARIO_PAGE_CONTEXT_REGISTRY[node.scenarioNode.semanticPath].create(node)
-
+        
         this.handleNodeStartEditing(node)
 
         this.notifyDomUpdate()

--- a/src/framework/src/resource/scenario/schema/schema.tsx
+++ b/src/framework/src/resource/scenario/schema/schema.tsx
@@ -62,7 +62,7 @@ export default class SchemaScenarioNode extends DefaultScenarioNode {
             case SchemaMenuItem.CHECK_INFO:
                 (nodeSelf.tree as SceneTree).startEditingNode(nodeSelf as SceneNode)
                 break
-            case SchemaMenuItem.DELETE:
+            case SchemaMenuItem.DELETE: {
                 const response = await deleteSchema(nodeSelf.name, nodeSelf.tree.isPublic)
                 if (response) {
                     toast.success(`Schema ${nodeSelf.name} deleted successfully`)
@@ -77,6 +77,7 @@ export default class SchemaScenarioNode extends DefaultScenarioNode {
                     toast.error(`Failed to delete schema ${nodeSelf.name}`)
                 }
                 break
+            }
         }
     }
 


### PR DESCRIPTION
Improve the `startEditingNode` method to ensure that a node is only added to the editing list if it is not already being edited. This change prevents unnecessary operations and enhances the overall efficiency of node editing.