### PR TITLE
Add pageId property to SceneNode and update handling in SchemasScenarioNode

### DIFF
--- a/src/framework/src/components/resourceScene/scene.ts
+++ b/src/framework/src/components/resourceScene/scene.ts
@@ -17,6 +17,7 @@ export class SceneNode implements ISceneNode {
     
     // Dom-related properties
     tab: Tab
+    pageId: string | null = null
     private _pageContext: DefaultPageContext | undefined | null = undefined // undefined: not editing, null: editing paused, object: editing in progress
 
     constructor(tree: SceneTree, node_key: string, parent: ISceneNode | null, scenarioNode: IScenarioNode) {
@@ -309,7 +310,9 @@ export class SceneTree implements ISceneTree {
 
         this.editingNodeIds.delete(node.id)
         
-        await (node as SceneNode).deletePageContext()
+        const _node = node as SceneNode
+        _node.pageId = null
+        await _node.deletePageContext()
 
         this.handleNodeStopEditing(node)
 

--- a/src/framework/src/resource/scenario/schemas/schemas.tsx
+++ b/src/framework/src/resource/scenario/schemas/schemas.tsx
@@ -71,15 +71,19 @@ export default class SchemasScenarioNode extends DefaultScenarioNode {
 
     handleMenuOpen(nodeSelf: ISceneNode, menuItem: any): void {
         switch (menuItem) {
-            case SchemasMenuItem.CREATE_NEW_SCHEMA:
-                (nodeSelf.tree as SceneTree).startEditingNode(nodeSelf as SceneNode)
+            case SchemasMenuItem.CREATE_NEW_SCHEMA: {
+                (nodeSelf as SceneNode).pageId = 'default'
+                ;(nodeSelf.tree as SceneTree).startEditingNode(nodeSelf as SceneNode)
                 break
+            }
         }
     }
 
     renderPage(nodeSelf: ISceneNode): React.JSX.Element | null {
-        return (
-            <SchemasPage node={nodeSelf} />
-        )
+        switch ((nodeSelf as SceneNode).pageId) {
+            case 'default':
+            default:
+                return (<SchemasPage node={nodeSelf} />)
+        }
     }
 }


### PR DESCRIPTION
Introduce a pageId property to SceneNode for better context management and update the handling in SchemasScenarioNode to utilize this new property during schema creation and rendering.